### PR TITLE
Changes to Heroku Buildpack API

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,5 @@ Open `bin/compile` in your editor, and change the following lines:
 Commit and push the changes to your buildpack to your Github fork, then push your sample app to Heroku to test.  You should see:
 
     -----> Vendoring node 0.6.7
+
+(nop)

--- a/bin/compile
+++ b/bin/compile
@@ -163,8 +163,37 @@ INCLUDE_PATH="$VENDORED_NODE/include"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 
+# unpack existing cache
+if [ -d $CACHE_STORE_DIR ]; then
+
+  # generate a place to put node_modules
+  TEMP_NODE_MODULES_DIR=$(mktmpdir node_modules)
+
+  # move existing node_modules out of the way
+  if [ -d $CACHE_TARGET_DIR ]; then
+    mv $CACHE_TARGET_DIR $TEMP_NODE_MODULES_DIR/
+  fi
+
+  # copy the cached node_modules in
+  mkdir -p $CACHE_TARGET_DIR
+  cp -R $CACHE_STORE_DIR/* $CACHE_TARGET_DIR/
+
+  # move existing node_modules back into place
+  if [ -d $TEMP_NODE_MODULES_DIR/node_modules ]; then
+    cp -R $TEMP_NODE_MODULES_DIR/node_modules/* $CACHE_TARGET_DIR/
+  fi
+
+fi
+
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"
 run_npm "install --production"
 run_npm "rebuild"
 echo "Dependencies installed" | indent
+
+# repack cache with new assets
+if [ -d $CACHE_TARGET_DIR ]; then
+  rm -rf $CACHE_STORE_DIR
+  mkdir -p $(dirname $CACHE_STORE_DIR)
+  cp -a $CACHE_TARGET_DIR $CACHE_STORE_DIR
+fi

--- a/bin/compile
+++ b/bin/compile
@@ -163,6 +163,9 @@ INCLUDE_PATH="$VENDORED_NODE/include"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 
+rm -rf $CACHE_STORE_DIR
+mkdir -p $CACHE_STORE_DIR
+
 # unpack existing cache
 if [ -d $CACHE_STORE_DIR ]; then
 
@@ -197,7 +200,7 @@ echo "Dependencies installed" | indent
 # repack cache with new assets
 if [ -d $CACHE_TARGET_DIR ]; then
   rm -rf $CACHE_STORE_DIR
-  mkdir -p $(dirname $CACHE_STORE_DIR)
+  mkdir -p $CACHE_STORE_DIR
   echo "caching to ${CACHE_STORE_DIR} from ${CACHE_TARGET_DIR}/"
   cp -av $CACHE_TARGET_DIR/ $CACHE_STORE_DIR
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -155,7 +155,7 @@ package_download "scons" "${SCONS_VERSION}" "${VENDORED_SCONS}"
 PATH="$BUILD_DIR/bin:$PATH"
 echo "-----> Vendoring node into slug"
 mkdir -p "$BUILD_DIR/bin"
-cp "$VENDORED_NODE/bin/node" "$BUILD_DIR/bin/node"
+cp -a "$VENDORED_NODE/bin/node" "$BUILD_DIR/bin/node"
 
 # setting up paths for building
 PATH="$VENDORED_SCONS:$VENDORED_NODE/bin:$PATH"
@@ -191,7 +191,7 @@ echo "-----> Installing dependencies with npm"
 run_npm "install --production"
 # Good Eggs - rebuild is there for those who check in npm modules which we don't, but we need to touch fibrous to avoid warnings.
 # Since we cached based on the version of node/npm; we should get a new version of fibrous built if we push a new version of node.
-FIBERS_SRC_FILE=$CACHE_TARGET_DIR/fibrous/node_modules/fiberssrc/fibers
+FIBERS_SRC_FILE=$CACHE_TARGET_DIR/fibrous/node_modules/fibers/src/fibers.node
 if [ -f $FIBERS_SRC_FILE ]; then
   touch $FIBERS_SRC_FILE
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -188,7 +188,8 @@ fi
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"
 run_npm "install --production"
-run_npm "rebuild"
+# Good Eggs - rebuild is there for those who check in npm modules which we don't
+# run_npm "rebuild"
 echo "Dependencies installed" | indent
 
 # repack cache with new assets

--- a/bin/compile
+++ b/bin/compile
@@ -163,6 +163,9 @@ INCLUDE_PATH="$VENDORED_NODE/include"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 
+  rm -rf $CACHE_STORE_DIR
+  mkdir -p $(dirname $CACHE_STORE_DIR)
+
 # unpack existing cache
 if [ -d $CACHE_STORE_DIR ]; then
 

--- a/bin/compile
+++ b/bin/compile
@@ -203,4 +203,4 @@ fi
 
 # run buildpack cake task
 cd $BUILD_DIR
-cake buildpack
+./node_modules/.bin/cake buildpack

--- a/bin/compile
+++ b/bin/compile
@@ -155,7 +155,7 @@ package_download "scons" "${SCONS_VERSION}" "${VENDORED_SCONS}"
 PATH="$BUILD_DIR/bin:$PATH"
 echo "-----> Vendoring node into slug"
 mkdir -p "$BUILD_DIR/bin"
-cp -a "$VENDORED_NODE/bin/node" "$BUILD_DIR/bin/node"
+cp -a "$VENDORED_NODE/bin/node" "$BUILD_DIR/bin/node" # -a to preserve the mtime of node, so that fibers doesn't complain about a rebuild
 
 # setting up paths for building
 PATH="$VENDORED_SCONS:$VENDORED_NODE/bin:$PATH"
@@ -189,12 +189,7 @@ fi
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"
 run_npm "install --production"
-# Good Eggs - rebuild is there for those who check in npm modules which we don't, but we need to touch fibrous to avoid warnings.
-# Since we cached based on the version of node/npm; we should get a new version of fibrous built if we push a new version of node.
-FIBERS_SRC_FILE=$CACHE_TARGET_DIR/fibrous/node_modules/fibers/src/fibers.node
-if [ -f $FIBERS_SRC_FILE ]; then
-  touch $FIBERS_SRC_FILE
-fi
+# Good Eggs - rebuild is there for those who check in npm modules which we don't.
 # run_npm "rebuild"
 echo "Dependencies installed" | indent
 

--- a/bin/compile
+++ b/bin/compile
@@ -200,3 +200,6 @@ if [ -d $CACHE_TARGET_DIR ]; then
   echo "caching to ${CACHE_STORE_DIR} from ${CACHE_TARGET_DIR}/"
   cp -a $CACHE_TARGET_DIR/ $CACHE_STORE_DIR
 fi
+
+# run buildpack cake task
+cake buildpack

--- a/bin/compile
+++ b/bin/compile
@@ -163,9 +163,6 @@ INCLUDE_PATH="$VENDORED_NODE/include"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 
-rm -rf $CACHE_STORE_DIR
-mkdir -p $CACHE_STORE_DIR
-
 # unpack existing cache
 if [ -d $CACHE_STORE_DIR ]; then
 

--- a/bin/compile
+++ b/bin/compile
@@ -166,6 +166,9 @@ export CPPPATH="$INCLUDE_PATH"
 # unpack existing cache
 if [ -d $CACHE_STORE_DIR ]; then
 
+  rm -rf $CACHE_STORE_DIR
+  mkdir -p $(dirname $CACHE_STORE_DIR)
+
   # generate a place to put node_modules
   TEMP_NODE_MODULES_DIR=$(mktmpdir node_modules)
 
@@ -176,12 +179,13 @@ if [ -d $CACHE_STORE_DIR ]; then
 
   # copy the cached node_modules in
   mkdir -p $CACHE_TARGET_DIR
-  echo "restoring from ${CACHE_STORE_DIR} to ${CACHE_TARGET_DIR}"
-  cp -av $CACHE_STORE_DIR/ $CACHE_TARGET_DIR/
+  echo "restoring from ${CACHE_STORE_DIR}/ to ${CACHE_TARGET_DIR}"
+  cp -av $CACHE_STORE_DIR/ $CACHE_TARGET_DIR
 
   # move existing node_modules back into place
   if [ -d $TEMP_NODE_MODULES_DIR/node_modules ]; then
-    cp -R $TEMP_NODE_MODULES_DIR/node_modules/* $CACHE_TARGET_DIR/
+    echo "restoring from ${TEMP_NODE_MODULES_DIR}/node_modules/* to ${CACHE_TARGET_DIR}/"
+    cp -Rv $TEMP_NODE_MODULES_DIR/node_modules/* $CACHE_TARGET_DIR/
   fi
 
 fi
@@ -197,6 +201,6 @@ echo "Dependencies installed" | indent
 if [ -d $CACHE_TARGET_DIR ]; then
   rm -rf $CACHE_STORE_DIR
   mkdir -p $(dirname $CACHE_STORE_DIR)
-  echo "caching to ${CACHE_STORE_DIR} from ${CACHE_TARGET_DIR}"
-  cp -av $CACHE_TARGET_DIR/ $CACHE_STORE_DIR/
+  echo "caching to ${CACHE_STORE_DIR} from ${CACHE_TARGET_DIR}/"
+  cp -av $CACHE_TARGET_DIR/ $CACHE_STORE_DIR
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -163,9 +163,6 @@ INCLUDE_PATH="$VENDORED_NODE/include"
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"
 
-  rm -rf $CACHE_STORE_DIR
-  mkdir -p $(dirname $CACHE_STORE_DIR)
-
 # unpack existing cache
 if [ -d $CACHE_STORE_DIR ]; then
 

--- a/bin/compile
+++ b/bin/compile
@@ -196,5 +196,5 @@ echo "Dependencies installed" | indent
 if [ -d $CACHE_TARGET_DIR ]; then
   rm -rf $CACHE_STORE_DIR
   mkdir -p $(dirname $CACHE_STORE_DIR)
-  cp -a $CACHE_TARGET_DIR $CACHE_STORE_DIR
+  cp -a $CACHE_TARGET_DIR/ $CACHE_STORE_DIR/
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -176,7 +176,7 @@ if [ -d $CACHE_STORE_DIR ]; then
 
   # copy the cached node_modules in
   mkdir -p $CACHE_TARGET_DIR
-  cp -R $CACHE_STORE_DIR/* $CACHE_TARGET_DIR/
+  cp -a $CACHE_STORE_DIR/ $CACHE_TARGET_DIR/
 
   # move existing node_modules back into place
   if [ -d $TEMP_NODE_MODULES_DIR/node_modules ]; then

--- a/bin/compile
+++ b/bin/compile
@@ -203,4 +203,5 @@ fi
 
 # run buildpack cake task
 cd $BUILD_DIR
-./node_modules/.bin/cake buildpack
+export PATH="./node_modules/.bin:$PATH"
+cake buildpack

--- a/bin/compile
+++ b/bin/compile
@@ -202,4 +202,5 @@ if [ -d $CACHE_TARGET_DIR ]; then
 fi
 
 # run buildpack cake task
-$BUILD_DIR/node_modules/.bin/cake buildpack
+cd $BUILD_DIR
+cake buildpack

--- a/bin/compile
+++ b/bin/compile
@@ -166,9 +166,6 @@ export CPPPATH="$INCLUDE_PATH"
 # unpack existing cache
 if [ -d $CACHE_STORE_DIR ]; then
 
-  rm -rf $CACHE_STORE_DIR
-  mkdir -p $(dirname $CACHE_STORE_DIR)
-
   # generate a place to put node_modules
   TEMP_NODE_MODULES_DIR=$(mktmpdir node_modules)
 

--- a/bin/compile
+++ b/bin/compile
@@ -189,7 +189,12 @@ fi
 # install dependencies with npm
 echo "-----> Installing dependencies with npm"
 run_npm "install --production"
-# Good Eggs - rebuild is there for those who check in npm modules which we don't
+# Good Eggs - rebuild is there for those who check in npm modules which we don't, but we need to touch fibrous to avoid warnings.
+# Since we cached based on the version of node/npm; we should get a new version of fibrous built if we push a new version of node.
+FIBERS_SRC_FILE=$CACHE_TARGET_DIR/fibrous/node_modules/fiberssrc/fibers
+if [ -f $FIBERS_SRC_FILE ]; then
+  touch $FIBERS_SRC_FILE
+fi
 # run_npm "rebuild"
 echo "Dependencies installed" | indent
 

--- a/bin/compile
+++ b/bin/compile
@@ -176,12 +176,12 @@ if [ -d $CACHE_STORE_DIR ]; then
 
   # copy the cached node_modules in - don't mkdir first to effectively recreate the CACHE_STORE_DIR as CACHE_TARGET_DIR
   echo "restoring from ${CACHE_STORE_DIR}/ to ${CACHE_TARGET_DIR}"
-  cp -av $CACHE_STORE_DIR/ $CACHE_TARGET_DIR
+  cp -a $CACHE_STORE_DIR/ $CACHE_TARGET_DIR
 
   # move existing node_modules back into place
   if [ -d $TEMP_NODE_MODULES_DIR/node_modules ]; then
     echo "restoring from ${TEMP_NODE_MODULES_DIR}/node_modules/* to ${CACHE_TARGET_DIR}/"
-    cp -Rv $TEMP_NODE_MODULES_DIR/node_modules/* $CACHE_TARGET_DIR/
+    cp -R $TEMP_NODE_MODULES_DIR/node_modules/* $CACHE_TARGET_DIR/
   fi
 
 fi
@@ -198,5 +198,5 @@ if [ -d $CACHE_TARGET_DIR ]; then
   rm -rf $CACHE_STORE_DIR
   mkdir -p $(dirname $CACHE_STORE_DIR) # Just make the parent dir to effectively recreate the CACHE_TARGET_DIR as CACHE_STORE_DIR
   echo "caching to ${CACHE_STORE_DIR} from ${CACHE_TARGET_DIR}/"
-  cp -av $CACHE_TARGET_DIR/ $CACHE_STORE_DIR
+  cp -a $CACHE_TARGET_DIR/ $CACHE_STORE_DIR
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -176,7 +176,8 @@ if [ -d $CACHE_STORE_DIR ]; then
 
   # copy the cached node_modules in
   mkdir -p $CACHE_TARGET_DIR
-  cp -a $CACHE_STORE_DIR/ $CACHE_TARGET_DIR/
+  echo "restoring from ${CACHE_STORE_DIR} to ${CACHE_TARGET_DIR}"
+  cp -av $CACHE_STORE_DIR/ $CACHE_TARGET_DIR/
 
   # move existing node_modules back into place
   if [ -d $TEMP_NODE_MODULES_DIR/node_modules ]; then
@@ -196,5 +197,6 @@ echo "Dependencies installed" | indent
 if [ -d $CACHE_TARGET_DIR ]; then
   rm -rf $CACHE_STORE_DIR
   mkdir -p $(dirname $CACHE_STORE_DIR)
-  cp -a $CACHE_TARGET_DIR/ $CACHE_STORE_DIR/
+  echo "caching to ${CACHE_STORE_DIR} from ${CACHE_TARGET_DIR}"
+  cp -av $CACHE_TARGET_DIR/ $CACHE_STORE_DIR/
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -177,8 +177,7 @@ if [ -d $CACHE_STORE_DIR ]; then
     mv $CACHE_TARGET_DIR $TEMP_NODE_MODULES_DIR/
   fi
 
-  # copy the cached node_modules in
-  mkdir -p $CACHE_TARGET_DIR
+  # copy the cached node_modules in - don't mkdir first to effectively recreate the CACHE_STORE_DIR as CACHE_TARGET_DIR
   echo "restoring from ${CACHE_STORE_DIR}/ to ${CACHE_TARGET_DIR}"
   cp -av $CACHE_STORE_DIR/ $CACHE_TARGET_DIR
 
@@ -200,7 +199,7 @@ echo "Dependencies installed" | indent
 # repack cache with new assets
 if [ -d $CACHE_TARGET_DIR ]; then
   rm -rf $CACHE_STORE_DIR
-  mkdir -p $CACHE_STORE_DIR
+  mkdir -p $(dirname $CACHE_STORE_DIR) # Just make the parent dir to effectively recreate the CACHE_TARGET_DIR as CACHE_STORE_DIR
   echo "caching to ${CACHE_STORE_DIR} from ${CACHE_TARGET_DIR}/"
   cp -av $CACHE_TARGET_DIR/ $CACHE_STORE_DIR
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -202,4 +202,4 @@ if [ -d $CACHE_TARGET_DIR ]; then
 fi
 
 # run buildpack cake task
-cake buildpack
+$BUILD_DIR/node_modules/.bin/cake buildpack


### PR DESCRIPTION
Hey there, I'm opening this PR because I cannot find contact info for the maintainers.

We are making some changes to the way app config is available during builds and those changes are likely to affect users of your buildpack. This is because many users of your buildpack have [user-env-compile](https://devcenter.heroku.com/articles/labs-user-env-compile) enabled. `user-env-compile`makes the app config available during builds.

The Node.js buildpack upstream from yours has already been updated, so you might be able to simply pull in those changes: https://github.com/heroku/heroku-buildpack-nodejs/pull/94

The change means that we will start injecting the application config into builds on all apps, not just ones with the `user-env-compile` [labs flag](https://devcenter.heroku.com/articles/labs-user-env-compile) set. The user-env-compile labs feature will eventually be deprecated.

With this change to the Buildpack API, app config is available to the buildpack’s `bin/compile` script as files in a directory. The location of the directory is passed as the third argument to the `bin/compile` script

``` term
bin/compile BUILD_DIR CACHE_DIR ENV_DIR
```

You can read more about how the `compile` script will work in this [staging-version of the Buildpack API documentation](https://devcenter.heroku.com/articles/buildpack-api-staging?preview=1#bin-compile). The article also has sample Bash code demonstrating how to read and export the contents of the `ENV_DIR` directory.

To get early access and test changes to your buildpack on a real app, you can enable the `buildpack-env-arg` labs feature by running:

``` term
$ heroku labs:enable buildpack-env-arg --app example-app
```

We expect to start passing the new argument to buildpacks on in the coming weeks. During the rollout, you should check for existence of the third argument to the `bin/compile` script. We will migrate apps with `user-env-compile` when relevant buildpacks are updated to support the `END_DIR` argument. Eventually, support for `user-env-compile` will be removed and all builds will be passed the ENV_DIR argument.

Once the rollout has completed, we recommend updating any buildpack documentation that mentions `user-env-compile`. Users will no longer have to add user-env-compile to use the application runtime environment during builds.

If we don’t hear back from you, we will try to contact affected users currently using `user-env-compile` to make them aware that builds with your buildpack may stop working and suggest workarounds.

Feel free to get in touch if you have any questions about this process.
