### PR TITLE
adds cronitor wrapper

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -86,6 +86,9 @@ install_bins() {
 
   echo "Installing npm-production"
   install $BP_DIR/vendor/npm-production/npm-production $BUILD_DIR/.heroku/node/bin
+
+  echo "Installing cronitor"
+  install $BP_DIR/vendor/cronitor/cronitor $BUILD_DIR/.heroku/node/bin
 }
 
 header "Installing binaries"

--- a/vendor/cronitor/cronitor
+++ b/vendor/cronitor/cronitor
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+cronitor_id=$1
+shift
+cmd=$@
+
+curl https://cronitor.link/${cronitor_id}/run -m 10
+
+(
+  eval $cmd
+)
+code=$?
+
+if [ $code -eq 0 ]; then
+  curl https://cronitor.link/${cronitor_id}/complete -m 10
+else
+  curl https://cronitor.link/${cronitor_id}/fail -m 10
+fi
+
+exit $code
+

--- a/vendor/npm-production/npm-production
+++ b/vendor/npm-production/npm-production
@@ -27,11 +27,11 @@
 
   commands = {
     prune: function(shrinkwrap, cb) {
-      var dir, e, moduleDirs, modulesToPrune, npm;
+      var dir, e, error, moduleDirs, modulesToPrune, npm;
       try {
         moduleDirs = fs.readdirSync('./node_modules');
-      } catch (_error) {
-        e = _error;
+      } catch (error) {
+        e = error;
         if (e.code !== 'ENOENT') {
           throw e;
         }
@@ -56,14 +56,14 @@
       });
     },
     install: function(shrinkwrap, cb) {
-      var cleanup, e, npm;
+      var cleanup, e, error, npm;
       cleanup = function() {
-        var e;
+        var e, error;
         try {
           console.log('restoring original npm-shrinkwrap.json');
           return fs.renameSync('./.full-npm-shrinkwrap.json', './npm-shrinkwrap.json');
-        } catch (_error) {
-          e = _error;
+        } catch (error) {
+          e = error;
         }
       };
       fs.writeFileSync('./.pruned-npm-shrinkwrap.json', JSON.stringify(shrinkwrap, null, '  '));
@@ -78,8 +78,8 @@
           cleanup();
           return cb(code !== 0 && new Error("non-zero exit code " + code) || null);
         });
-      } catch (_error) {
-        e = _error;
+      } catch (error) {
+        e = error;
         cleanup();
         throw e;
       }
@@ -91,26 +91,23 @@
 
   command = (ref = process.argv[2]) != null ? ref.toLowerCase() : void 0;
 
-  switch (command) {
-    case 'prune':
-    case 'install':
-      console.log("npm-production is handling `npm " + command + "`");
-      shrinkwrap = buildPrunedShrinkwrap();
-      commands[command](shrinkwrap, function(err) {
-        var ref1;
-        if (err != null) {
-          console.error((ref1 = err.stack) != null ? ref1 : err);
-        }
-        return process.exit((err != null) && 1 || 0);
-      });
-      break;
-    default:
-      npm = spawn('npm', process.argv.slice(2), {
-        stdio: 'inherit'
-      });
-      npm.on('close', function(code) {
-        return process.exit(code);
-      });
+  if ((command === 'prune' || command === 'install') && fs.existsSync('./package.json') && fs.existsSync('./npm-shrinkwrap.json')) {
+    console.log("npm-production is handling `npm " + command + "`");
+    shrinkwrap = buildPrunedShrinkwrap();
+    commands[command](shrinkwrap, function(err) {
+      var ref1;
+      if (err != null) {
+        console.error((ref1 = err.stack) != null ? ref1 : err);
+      }
+      return process.exit((err != null) && 1 || 0);
+    });
+  } else {
+    npm = spawn('npm', process.argv.slice(2), {
+      stdio: 'inherit'
+    });
+    npm.on('close', function(code) {
+      return process.exit(code);
+    });
   }
 
 }).call(this);

--- a/vendor/npm-production/npm-production.coffee
+++ b/vendor/npm-production/npm-production.coffee
@@ -62,16 +62,18 @@ commands =
 
 command = process.argv[2]?.toLowerCase()
 
-switch command
-  when 'prune', 'install'
+if command in ['prune', 'install'] \
+  and fs.existsSync('./package.json') \
+  and fs.existsSync('./npm-shrinkwrap.json')
     console.log "npm-production is handling `npm #{command}`"
     shrinkwrap = buildPrunedShrinkwrap()
     commands[command] shrinkwrap, (err) ->
       console.error(err.stack ? err) if err?
       process.exit err? and 1 or 0
-
-  else # passthru
-    npm = spawn 'npm', process.argv[2..], {stdio: 'inherit'}
-    npm.on 'close', (code) ->
-      process.exit code
+  
+else
+  # passthru
+  npm = spawn 'npm', process.argv[2..], {stdio: 'inherit'}
+  npm.on 'close', (code) ->
+    process.exit code
 


### PR DESCRIPTION
https://cronitor.io is a useful service that lets us alert around scheduled jobs.  This adds a wrapper script for it.

```
$ cronitor <cronitor_id> 'your scheduled command here'
```

also included: `npm-production` now ignores projects that don't have a shrinkwrap, so we can use this buildpack everywhere.

/cc @goodeggs/delivery-eng 
